### PR TITLE
Fix: wineモデルのrspecテストが通るようにFactoryBotの設定を修正　#9

### DIFF
--- a/app/models/aroma.rb
+++ b/app/models/aroma.rb
@@ -1,6 +1,6 @@
 class Aroma < ApplicationRecord
   validates :name, presence: true
-  
-  has_many: wine_aromas
-  has_many: wines, through: :wine_aromas
+
+  has_many :wine_aromas, dependent: :destroy
+  has_many :wines, through: :wine_aromas
 end

--- a/app/models/grape_variety.rb
+++ b/app/models/grape_variety.rb
@@ -1,6 +1,6 @@
 class GrapeVariety < ApplicationRecord
   validates :name, presence: true
 
-  has_many :wine_grapes
+  has_many :wine_grapes, dependent: :destroy
   has_many :wines, through: :wine_grapes
 end

--- a/app/models/wine.rb
+++ b/app/models/wine.rb
@@ -6,7 +6,7 @@ class Wine < ApplicationRecord
     t.integer "vintage", null: false
     t.string "label"
     t.string "image"
-    t.integer "type", default: 0, null: false
+    t.integer "category", default: 0, null: false
     t.integer "color", default: 0, null: false
     t.integer "price"
     t.text "description"
@@ -24,7 +24,7 @@ class Wine < ApplicationRecord
 validates :name, presence: true
 validates :producer, presence: true
 validates :vintage, presence: true
-validates :type, presence: true
+validates :category, presence: true
 validates :color, presence: true
 validates :sweetness, presence: true
 validates :body, presence: true
@@ -33,9 +33,9 @@ validates :tannin, presence: true
 
   has_many :wine_aromas
   has_many :wine_grapes
-  has_many :grape_varieties, through: wine_grapes
+  has_many :grape_varieties, through: :wine_grapes
   has_many :aromas, through: :wine_aromas
   belongs_to :region
-  enum type: { still: 0, sparkling: 1 }
+  enum category: { still: 0, sparkling: 1 }
   enum color: { red: 0, white: 1, rose: 2, other: 3 }
 end

--- a/db/fixtures/aromas.rb
+++ b/db/fixtures/aromas.rb
@@ -1,0 +1,14 @@
+Aroma.seed do |s|
+  s.id    = 1
+  s.name  = 'Humus'
+end
+
+Aroma.seed do |s|
+  s.id    = 2
+  s.name  = 'Violet'
+end
+
+Aroma.seed do |s|
+  s.id    = 3
+  s.name  = 'Chocolate'
+end

--- a/db/fixtures/grape_varieties.rb
+++ b/db/fixtures/grape_varieties.rb
@@ -1,0 +1,4 @@
+GrapeVariety.seed do |s|
+  s.id    = 1
+  s.name  = 'Nebbiolo'
+end

--- a/db/migrate/20220911160259_rename_type_column_to_category.rb
+++ b/db/migrate/20220911160259_rename_type_column_to_category.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToCategory < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :wines, :type, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_09_155156) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_11_160259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,7 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_155156) do
     t.integer "vintage", null: false
     t.string "label"
     t.string "image"
-    t.integer "type", default: 0, null: false
+    t.integer "category", default: 0, null: false
     t.integer "color", default: 0, null: false
     t.integer "price"
     t.text "description"

--- a/spec/factories/aromas.rb
+++ b/spec/factories/aromas.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :aroma do
+    
+  end
+end

--- a/spec/factories/grape_varieties.rb
+++ b/spec/factories/grape_varieties.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :grape_variety do
+    
+  end
+end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :region do
+    name { "Piemonte" }
+  end
+end

--- a/spec/factories/wine_aromas.rb
+++ b/spec/factories/wine_aromas.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :wine_aromas do
+    association :wine
+    association :aroma
+  end
+end

--- a/spec/factories/wine_grapes.rb
+++ b/spec/factories/wine_grapes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :wine_grapes do
+    association :wine
+    association :grape_variety
+  end
+end

--- a/spec/factories/wines.rb
+++ b/spec/factories/wines.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :wine do
+    association :region
     name { "バローロ ラヴェーラ" }
     producer { "ELVIO COGNO" }
     vintage { 2017 }
-    type { 0 }
+    category { 0 }
     color { 0 }
     sweetness { 1 }
     body { 3 }
     acidity { 3 }
     tannin { 3 }
-    region_id { 2 }
   end
 end

--- a/spec/models/aroma_spec.rb
+++ b/spec/models/aroma_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Aroma, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/grape_variety_spec.rb
+++ b/spec/models/grape_variety_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GrapeVariety, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Region, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/wine_aromas_spec.rb
+++ b/spec/models/wine_aromas_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WineAromas, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/wine_grapes_spec.rb
+++ b/spec/models/wine_grapes_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WineGrapes, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 変更の概要
WineモデルのRSpecテストが通るようにFactoryBotの設定を修正。
RegionモデルのFactoryBotを作りWineとアソシエーションを定義。


## 課題
Seed-fuのデータはRSpecにはそのまま適用できない様子。
テスト用にseed-fuで定義しているデータを別で作るのか、
FactoryBotにseedのデータも集約するのか。
後者にできた方が無駄がないはず。